### PR TITLE
TTWEBTAKEN-169: Add support for nvm/.nvmrc

### DIFF
--- a/src/ThemeCompile.php
+++ b/src/ThemeCompile.php
@@ -58,10 +58,9 @@ class ThemeCompile extends ParallelExec
             );
         }
         if (file_exists($this->dir . '/package.json')) {
-            $executable = '';
-            if (file_exists($this->dir . '/.nvmrc')) {
-              $executable = '. ~/.nvm/nvm.sh && nvm exec ';
-            }
+            $executable = file_exists($this->dir . '/.nvmrc')
+                ? '. ~/.nvm/nvm.sh && nvm exec '
+                : '';
             $executable .= $this->findExecutable(file_exists($this->dir . '/yarn.lock') ? 'yarn' : 'npm');
             $this->processes[] = Process::fromShellCommandline(
                 $this->receiveCommand($executable . ' install'),

--- a/src/ThemeCompile.php
+++ b/src/ThemeCompile.php
@@ -58,7 +58,11 @@ class ThemeCompile extends ParallelExec
             );
         }
         if (file_exists($this->dir . '/package.json')) {
-            $executable = $this->findExecutable(file_exists($this->dir . '/yarn.lock') ? 'yarn' : 'npm');
+            $executable = '';
+            if (file_exists($this->dir . '/.nvmrc')) {
+              $executable = '. ~/.nvm/nvm.sh && nvm exec ';
+            }
+            $executable .= $this->findExecutable(file_exists($this->dir . '/yarn.lock') ? 'yarn' : 'npm');
             $this->processes[] = Process::fromShellCommandline(
                 $this->receiveCommand($executable . ' install'),
                 $this->dir,


### PR DESCRIPTION
To facilitate the upgrade to new node versions, add support for nvm and .nvmrc files. This way devs/frontenders can pin their node version to the required or desired version.